### PR TITLE
Injecting 3scale credentials to container

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -32,11 +32,6 @@ objects:
               secretKeyRef:
                 name: 3scale
                 key: three_scale_api_access_key
-          - name: THREE_SCALE_API_HOST_URL
-            valueFrom:
-              secretKeyRef:
-                name: 3scale
-                key: three_scale_api_host_url
           - name: THREE_SCALE_API_ACCOUNT_ID
             valueFrom:
               secretKeyRef:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -37,7 +37,7 @@ objects:
                 key: three_scale_api_account_id
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: f8a-3scale-admin-gateway
-        ports:
+          ports:
           - containerPort: 5000
             protocol: TCP
           readinessProbe:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -25,8 +25,6 @@ objects:
         - env:
           - name: GUNICORN_CMD_ARGS
             value: "${GUNICORN_CMD_ARGS}"
-          image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
-          name: f8a-3scale-admin-gateway
           - name: THREE_SCALE_API_ACCESS_KEY
             valueFrom:
               secretKeyRef:
@@ -37,6 +35,8 @@ objects:
               secretKeyRef:
                 name: 3scale
                 key: three_scale_api_account_id
+          image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
+          name: f8a-3scale-admin-gateway
         ports:
           - containerPort: 5000
             protocol: TCP

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -35,6 +35,11 @@ objects:
               secretKeyRef:
                 name: 3scale
                 key: three_scale_api_account_id
+          - name: THREE_SCALE_API_HOST_URL
+            valueFrom:
+              configMapKeyRef:
+                name: bayesian-config
+                key: three-scale-api-host-url
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: f8a-3scale-admin-gateway
           ports:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -27,7 +27,22 @@ objects:
             value: "${GUNICORN_CMD_ARGS}"
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: f8a-3scale-admin-gateway
-          ports:
+          - name: THREE_SCALE_API_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: 3scale
+                key: three_scale_api_access_key
+          - name: THREE_SCALE_API_HOST_URL
+            valueFrom:
+              secretKeyRef:
+                name: 3scale
+                key: three_scale_api_host_url
+          - name: THREE_SCALE_API_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: 3scale
+                key: three_scale_api_account_id
+        ports:
           - containerPort: 5000
             protocol: TCP
           readinessProbe:


### PR DESCRIPTION
This commit injects 'three_scale_api_access_key',
'three_scale_api_account' and 'three_scale_api_host_url'
from secret keys into the 3scale container.